### PR TITLE
Add missing entry for ER_XPATH_ERROR in XPATHErrorResources

### DIFF
--- a/src/main/java/org/htmlunit/xpath/res/XPATHErrorResources.java
+++ b/src/main/java/org/htmlunit/xpath/res/XPATHErrorResources.java
@@ -262,6 +262,7 @@ public class XPATHErrorResources extends ListResourceBundle {
       // The message indicates that syntactically such an expression was expected,
       // but was not found.
       {ER_EXPECTED_REL_PATH_PATTERN, "A relative path pattern was expected."},
+      {ER_XPATH_ERROR, "Unknown error in XPath."},
       {ER_CANNOT_OVERWRITE_CAUSE, "Cannot overwrite cause"},
       {ER_ITERATOR_AXIS_NOT_IMPLEMENTED, "Error: iterator for axis {0} not implemented "},
       {ER_ITERATOR_CLONE_NOT_SUPPORTED, "Iterator clone not supported"},


### PR DESCRIPTION
### This PR does the following

Add missing `ER_XPATH_ERROR` entry to `XPATHErrorResources.getContents()`. This was the only declared static variable without a corresponding message, which would cause a `MissingResourceException` at runtime when a XPath error was triggered.

The content is copied from https://github.com/apache/xalan-j/blob/xalan-j_2_7_2/src/org/apache/xpath/res/XPATHErrorResources.java#L754

### Remark

I'm not the one who identified and proposed the fix for this issue. Credit belong to `Ryuhei Ishizuka` instead.